### PR TITLE
fix(security): backfill-encrypt existing hosting passwords

### DIFF
--- a/database/migrations/2026_06_28_000000_encrypt_web_hosting_account_passwords.php
+++ b/database/migrations/2026_06_28_000000_encrypt_web_hosting_account_passwords.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Contracts\Encryption\DecryptException;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Encrypt pre-existing plaintext passwords now that the model casts
+     * `password` to `encrypted`. Raw DB access bypasses the model cast.
+     * Idempotent: rows that already decrypt are left untouched, so this
+     * is safe to re-run.
+     */
+    public function up(): void
+    {
+        DB::table('web_hosting_accounts')
+            ->select('id', 'password')
+            ->whereNotNull('password')
+            ->cursor()
+            ->each(function ($row) {
+                try {
+                    Crypt::decryptString($row->password);
+
+                    return; // already encrypted
+                } catch (DecryptException) {
+                    // plaintext — encrypt below
+                }
+
+                DB::table('web_hosting_accounts')
+                    ->where('id', $row->id)
+                    ->update(['password' => Crypt::encryptString($row->password)]);
+            });
+    }
+
+    /**
+     * No down(): decrypting back to plaintext would re-introduce the
+     * vulnerability this migration fixes.
+     */
+    public function down(): void
+    {
+        // intentionally irreversible
+    }
+};


### PR DESCRIPTION
**Follow-up to #454 — merge before next deploy.**

#454 merged the `WebHostingAccount.password => encrypted` cast but this backfill migration landed on the branch *after* the merge, so it's missing from main. Result: any pre-existing plaintext `web_hosting_accounts.password` row throws `DecryptException` when the cast reads it.

This migration encrypts those rows once via raw DB access (bypasses the cast). Idempotent — skips rows that already decrypt, safe to re-run. Irreversible by design (no down()).