### PR TITLE
test: assert SecurityHeaders middleware sets headers

### DIFF
--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    /**
+     * The SecurityHeaders middleware sets its headers on every response.
+     */
+    public function test_security_headers_are_present_on_responses(): void
+    {
+        $response = $this->get('/');
+
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+        $response->assertHeader('X-Frame-Options', 'SAMEORIGIN');
+        $response->assertHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+    }
+}


### PR DESCRIPTION
Adds a feature test guarding the global `SecurityHeaders` middleware introduced in #454.

Asserts a GET `/` response carries the three headers with their exact values:
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: SAMEORIGIN`
- `Referrer-Policy: strict-origin-when-cross-origin`

Mirrors the existing `ExampleTest` request style (no DB). Test-only, no app-code changes.

Local run not possible (no `vendor/`, no php on PATH); syntax checked via PHP 8.5. CI (`tests.yml`) verifies.