### PR TITLE
test: guard tenant access gating (canAccessTenant)

### DIFF
--- a/tests/Feature/TenantAccessTest.php
+++ b/tests/Feature/TenantAccessTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class TenantAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_access_team_they_own(): void
+    {
+        $user = User::factory()->create();
+        $team = Team::forceCreate([
+            'user_id' => $user->id,
+            'name' => 'Owned Team',
+            'personal_team' => true,
+        ]);
+
+        $this->assertTrue($user->canAccessTenant($team));
+    }
+
+    public function test_user_can_access_team_they_are_a_member_of(): void
+    {
+        $owner = User::factory()->create();
+        $member = User::factory()->create();
+        $team = Team::forceCreate([
+            'user_id' => $owner->id,
+            'name' => 'Shared Team',
+            'personal_team' => false,
+        ]);
+        $member->teams()->attach($team, ['role' => 'admin']);
+
+        $this->assertTrue($member->fresh()->canAccessTenant($team));
+    }
+
+    public function test_user_cannot_access_team_they_do_not_belong_to(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $foreignTeam = Team::forceCreate([
+            'user_id' => $other->id,
+            'name' => 'Foreign Team',
+            'personal_team' => true,
+        ]);
+
+        $this->assertFalse($user->canAccessTenant($foreignTeam));
+    }
+}


### PR DESCRIPTION
## Why

Regression guard for #454, which fixed `App\Models\User::canAccessTenant(Model \$tenant)` to return `\$this->allTeams()->contains(\$tenant)` instead of a hardcoded `true`. Without a test, a future refactor could silently revert to allowing any user into any tenant (cross-tenant data exposure).

## What

Adds `tests/Feature/TenantAccessTest.php` (RefreshDatabase, matching the existing `UserTest`/`ModuleSystemTest` style):

- `test_user_can_access_team_they_own` — owner's team is in `allTeams()` → `canAccessTenant` true.
- `test_user_can_access_team_they_are_a_member_of` — team-membership (team_user pivot) → true.
- `test_user_cannot_access_team_they_do_not_belong_to` — foreign team owned by another user → false. This is the assertion that fails against the old hardcoded `true`.

Teams are created with `Team::forceCreate(...)` to avoid depending on a `TeamFactory` (none exists in this repo). No app code touched; one new test file only.

## Local run

Could not run locally: this sandbox has no PHP and `composer install` fails because GitHub codeload returns HTTP 400 for dist downloads (network restriction). Relying on the `Tests` GitHub Actions workflow (PHP 8.5, sqlite :memory:) to verify.