### PR TITLE
fix(fortify): app won't boot — passkeys() unsupported on v1.36.2

### DIFF
--- a/config/fortify.php
+++ b/config/fortify.php
@@ -172,9 +172,12 @@ return [
             'confirmPassword' => true,
             // 'window' => 0,
         ]),
-        Features::passkeys([
-            'confirmPassword' => true,
-        ]),
+        // ponytail: Features::passkeys() requires Fortify v2; locked at v1.36.2,
+        // so calling it fatals package:discover and the app won't boot. Re-enable
+        // when upgrading laravel/fortify to ^2 (passkeys table migration already exists).
+        // Features::passkeys([
+        //     'confirmPassword' => true,
+        // ]),
     ],
 
 ];


### PR DESCRIPTION
## Critical — main does not boot

`config/fortify.php` calls `Features::passkeys([...])`, but that method only exists in **Fortify v2**. The lockfile pins **laravel/fortify v1.36.2**, which has no `passkeys()` — so `artisan package:discover` throws `Call to undefined method Laravel\\Fortify\\Features::passkeys()` on every `composer install`. The app cannot boot and **all CI jobs fail at the install step** (seen on PRs #461/#462/#463).

## Fix
Comment out the `passkeys` feature block. It was non-functional on v1.36.2 anyway. The passkeys migration stays; re-enable the feature when `laravel/fortify` is upgraded to `^2` (separate task).

Unblocks CI for the open test PRs.