### PR TITLE
fix(tests): make test suite runnable (passkeys migration + test key)

### DIFF
--- a/database/migrations/2024_01_01_000000_create_passkeys_table.php
+++ b/database/migrations/2024_01_01_000000_create_passkeys_table.php
@@ -2,8 +2,8 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use App\Models\User;
 use Illuminate\Support\Facades\Schema;
-use Laravel\Passkeys\Passkeys;
 
 return new class extends Migration
 {
@@ -14,7 +14,10 @@ return new class extends Migration
     {
         Schema::create('passkeys', function (Blueprint $table) {
             $table->id();
-            $table->foreignIdFor(Passkeys::userModel(), 'user_id')->constrained()->cascadeOnDelete();
+            // ponytail: was Passkeys::userModel() from laravel/passkeys (not installed,
+            // fataled every migration). Point at the app User model directly until the
+            // passkeys package + Fortify v2 land.
+            $table->foreignIdFor(User::class, 'user_id')->constrained()->cascadeOnDelete();
             $table->string('name');
             $table->string('credential_id')->unique();
             $table->json('credential');

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:CZktrmIn2N3q4L1bJwy32Cn7IVvzo7P9ynsC81jHHtQ="/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_DRIVER" value="array"/>
         <env name="MAIL_MAILER" value="array"/>


### PR DESCRIPTION
Follow-on to the Fortify boot fix (#464). With boot working, the suite now runs and exposed two more pre-existing breakages — both block **all** tests:

1. **passkeys migration** imports `Laravel\Passkeys\Passkeys` (package not installed) and calls `Passkeys::userModel()` → `Class "Laravel\Passkeys\Passkeys" not found` on every `RefreshDatabase`. Fixed: `foreignIdFor(App\Models\User::class, ...)`. Table unchanged; re-point at the package when passkeys/Fortify v2 land.
2. **No test APP_KEY**: `APP_ENV=testing` loads `.env.testing`, whose `APP_KEY` was blanked for security (#454) → `MissingAppKeyException`. Fixed: throwaway non-secret `APP_KEY` in `phpunit.xml` (test-only, deterministic).

Unblocks CI for the test PRs #461/#462/#463.