### PR TITLE
test(billing): verify Stripe webhook signature + lifecycle (T6)

### DIFF
--- a/tests/Feature/Billing/StripeWebhookTest.php
+++ b/tests/Feature/Billing/StripeWebhookTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Billing;
+
+use App\Models\Team;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StripeWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function team(string $stripeId): Team
+    {
+        $user = User::factory()->create();
+
+        return Team::forceCreate([
+            'user_id' => $user->id,
+            'name' => 'Acme',
+            'personal_team' => true,
+            'stripe_id' => $stripeId,
+        ]);
+    }
+
+    public function test_invalid_signature_is_rejected(): void
+    {
+        config()->set('cashier.webhook.secret', 'whsec_test_secret');
+
+        $response = $this->postJson('stripe/webhook', [
+            'id' => 'evt_1',
+            'type' => 'customer.subscription.deleted',
+        ], ['Stripe-Signature' => 'bogus']);
+
+        $response->assertForbidden();
+    }
+
+    public function test_subscription_deleted_event_cancels_local_subscription(): void
+    {
+        // No webhook secret => Cashier skips signature verification in this test.
+        config()->set('cashier.webhook.secret', null);
+
+        $team = $this->team('cus_test123');
+        $team->subscriptions()->create([
+            'type' => 'default',
+            'stripe_id' => 'sub_test123',
+            'stripe_status' => 'active',
+            'stripe_price' => 'price_pro',
+            'quantity' => 1,
+        ]);
+
+        $this->postJson('stripe/webhook', [
+            'id' => 'evt_2',
+            'type' => 'customer.subscription.deleted',
+            'data' => ['object' => ['id' => 'sub_test123', 'customer' => 'cus_test123']],
+        ])->assertOk();
+
+        $this->assertSame('canceled', $team->subscriptions()->first()->stripe_status);
+    }
+}


### PR DESCRIPTION
Third billing phase (T6). Webhooks.

> **Base is `feat/billing-plans-subscribe` (#470)** — stacked on T4→T5.

## Outcome: no new app code needed
Cashier already registers `POST stripe/webhook` with signature verification and handles the subscription lifecycle (created/updated/deleted). T6's job is to **prove the contract**, not rebuild it:

- invalid `Stripe-Signature` → **403** (when secret set)
- `customer.subscription.deleted` → local subscription **canceled**

`STRIPE_WEBHOOK_SECRET` already documented in `.env.example` (Cashier reads it via `config('cashier.webhook.secret')`).

## Tests (TDD)
`StripeWebhookTest` (2). Full suite **34 green**.

Fulfillment (provision/suspend hosting on subscription state) lands in **T7** via Cashier's `WebhookHandled` event — no custom controller required.