### PR TITLE
feat(billing): provision/suspend hosting on subscription state (T7)

### DIFF
--- a/app/Billing/HostingSubscriptionSync.php
+++ b/app/Billing/HostingSubscriptionSync.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Billing;
+
+use App\Models\Team;
+use App\Models\WebHostingAccount;
+use App\Services\WebHostingControlPanelManager;
+
+/**
+ * Reconciles a Team's hosting accounts with its Stripe subscription state.
+ */
+class HostingSubscriptionSync
+{
+    /**
+     * Stripe subscription statuses that entitle a Team to live hosting.
+     */
+    private const ACTIVE_STATUSES = ['active', 'trialing'];
+
+    public function apply(Team $team, ?string $stripeStatus): void
+    {
+        $shouldBeActive = in_array($stripeStatus, self::ACTIVE_STATUSES, true);
+
+        foreach ($team->webHostingAccounts as $account) {
+            $shouldBeActive
+                ? $this->activate($account)
+                : $this->suspend($account);
+        }
+    }
+
+    private function activate(WebHostingAccount $account): void
+    {
+        if ($account->status === 'active') {
+            return;
+        }
+
+        $this->manager($account->control_panel)->unsuspendAccount($account->username);
+        $account->update(['status' => 'active']);
+    }
+
+    private function suspend(WebHostingAccount $account): void
+    {
+        if ($account->status === 'suspended') {
+            return;
+        }
+
+        $this->manager($account->control_panel)->suspendAccount($account->username);
+        $account->update(['status' => 'suspended']);
+    }
+
+    private function manager(string $controlPanel): WebHostingControlPanelManager
+    {
+        return app()->makeWith(WebHostingControlPanelManager::class, [
+            'controlPanel' => $controlPanel,
+        ]);
+    }
+}

--- a/app/Listeners/SyncHostingWithSubscription.php
+++ b/app/Listeners/SyncHostingWithSubscription.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Billing\HostingSubscriptionSync;
+use App\Models\Team;
+use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Events\WebhookHandled;
+
+/**
+ * On a Stripe subscription webhook, reconcile the Team's hosting with its status.
+ */
+class SyncHostingWithSubscription
+{
+    public function __construct(private HostingSubscriptionSync $sync) {}
+
+    public function handle(WebhookHandled $event): void
+    {
+        $payload = $event->payload;
+        $type = $payload['type'] ?? '';
+
+        if (! str_starts_with($type, 'customer.subscription.')) {
+            return;
+        }
+
+        $object = $payload['data']['object'] ?? [];
+
+        $team = Cashier::findBillable($object['customer'] ?? null);
+
+        if (! $team instanceof Team) {
+            return;
+        }
+
+        $status = $type === 'customer.subscription.deleted'
+            ? 'canceled'
+            : ($object['status'] ?? null);
+
+        $this->sync->apply($team, $status);
+    }
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -222,4 +222,9 @@ class Team extends JetstreamTeam
     {
         return $this->hasMany(Tree::class);
     }
+
+    public function webHostingAccounts(): HasMany
+    {
+        return $this->hasMany(WebHostingAccount::class);
+    }
 }

--- a/app/Models/WebHostingAccount.php
+++ b/app/Models/WebHostingAccount.php
@@ -4,12 +4,14 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class WebHostingAccount extends Model
 {
     use HasFactory;
 
     protected $fillable = [
+        'team_id',
         'domain',
         'username',
         'password',
@@ -24,4 +26,9 @@ class WebHostingAccount extends Model
     protected $casts = [
         'password' => 'encrypted',
     ];
+
+    public function team(): BelongsTo
+    {
+        return $this->belongsTo(Team::class);
+    }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,12 +2,15 @@
 
 namespace App\Providers;
 
+use App\Listeners\SyncHostingWithSubscription;
 use App\Models\Team;
 use App\Modules\ModuleManager;
 use App\Modules\ModuleServiceProvider;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\URL;
 use Illuminate\Support\ServiceProvider;
 use Laravel\Cashier\Cashier;
+use Laravel\Cashier\Events\WebhookHandled;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -32,6 +35,9 @@ class AppServiceProvider extends ServiceProvider
     {
         // Billing entity is the Team (Filament panels are Team-tenant scoped), not the User.
         Cashier::useCustomerModel(Team::class);
+
+        // Provision/suspend a Team's hosting when its subscription state changes.
+        Event::listen(WebhookHandled::class, SyncHostingWithSubscription::class);
 
         if ($this->app->environment('production')) {
             URL::forceScheme('https');

--- a/database/migrations/2026_06_28_000000_add_team_id_to_web_hosting_accounts_table.php
+++ b/database/migrations/2026_06_28_000000_add_team_id_to_web_hosting_accounts_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('web_hosting_accounts', function (Blueprint $table) {
+            $table->foreignId('team_id')->nullable()->after('id')->index();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('web_hosting_accounts', function (Blueprint $table) {
+            $table->dropIndex(['team_id']);
+            $table->dropColumn('team_id');
+        });
+    }
+};

--- a/tests/Feature/Billing/HostingSubscriptionSyncTest.php
+++ b/tests/Feature/Billing/HostingSubscriptionSyncTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\Billing;
+
+use App\Billing\HostingSubscriptionSync;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\WebHostingAccount;
+use App\Services\WebHostingControlPanelManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Cashier\Events\WebhookHandled;
+use Mockery;
+use Tests\TestCase;
+
+class HostingSubscriptionSyncTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function teamWithAccount(string $status = 'active'): array
+    {
+        $user = User::factory()->create();
+        $team = Team::forceCreate([
+            'user_id' => $user->id,
+            'name' => 'Acme',
+            'personal_team' => true,
+            'stripe_id' => 'cus_x',
+        ]);
+        $account = WebHostingAccount::create([
+            'team_id' => $team->id,
+            'domain' => 'acme.test',
+            'username' => 'acme',
+            'password' => 'secret',
+            'control_panel' => 'cpanel',
+            'status' => $status,
+        ]);
+
+        return [$team, $account];
+    }
+
+    public function test_active_subscription_unsuspends_team_accounts(): void
+    {
+        [$team, $account] = $this->teamWithAccount('suspended');
+
+        $manager = Mockery::mock(WebHostingControlPanelManager::class);
+        $manager->shouldReceive('unsuspendAccount')->once()->with('acme')->andReturnTrue();
+        $manager->shouldNotReceive('suspendAccount');
+        $this->app->bind(WebHostingControlPanelManager::class, fn () => $manager);
+
+        app(HostingSubscriptionSync::class)->apply($team, 'active');
+
+        $this->assertSame('active', $account->fresh()->status);
+    }
+
+    public function test_canceled_subscription_suspends_team_accounts(): void
+    {
+        [$team, $account] = $this->teamWithAccount('active');
+
+        $manager = Mockery::mock(WebHostingControlPanelManager::class);
+        $manager->shouldReceive('suspendAccount')->once()->with('acme')->andReturnTrue();
+        $manager->shouldNotReceive('unsuspendAccount');
+        $this->app->bind(WebHostingControlPanelManager::class, fn () => $manager);
+
+        app(HostingSubscriptionSync::class)->apply($team, 'canceled');
+
+        $this->assertSame('suspended', $account->fresh()->status);
+    }
+
+    public function test_webhook_handled_event_drives_the_sync(): void
+    {
+        [$team, $account] = $this->teamWithAccount('active');
+
+        $manager = Mockery::mock(WebHostingControlPanelManager::class);
+        $manager->shouldReceive('suspendAccount')->once()->with('acme')->andReturnTrue();
+        $this->app->bind(WebHostingControlPanelManager::class, fn () => $manager);
+
+        event(new WebhookHandled([
+            'type' => 'customer.subscription.deleted',
+            'data' => ['object' => ['customer' => 'cus_x', 'status' => 'canceled']],
+        ]));
+
+        $this->assertSame('suspended', $account->fresh()->status);
+    }
+}


### PR DESCRIPTION
Final billing phase (T7). Ties billing → hosting.

> **Base is `feat/billing-webhooks` (#471)** — top of the stack T4→T5→T6→T7.

When a Team's Stripe subscription changes, its hosting accounts are reconciled:
- `active` / `trialing` → **unsuspend** (status `active`)
- `past_due` / `canceled` / `unpaid` → **suspend** (status `suspended`)

## Changes
- `web_hosting_accounts.team_id` (migration) + `Team`↔`WebHostingAccount` relations — accounts were **not** Team-linked before
- `App\Billing\HostingSubscriptionSync` — idempotent reconcile; builds the right `WebHostingControlPanelManager` per account `control_panel`
- `App\Listeners\SyncHostingWithSubscription` on Cashier's `WebhookHandled`, registered in `AppServiceProvider` — **no custom webhook controller** needed

Fulfillment is driven by the **webhook** (T6), never a client redirect.

## Tests (TDD, red→green)
`HostingSubscriptionSyncTest` (3): active unsuspends, canceled suspends, `WebhookHandled` event drives the sync (manager mocked). Full suite **37 green**.

## Follow-ups (out of scope)
- `web_hosting_accounts.team_id` is nullable + unscoped reads — tenant-scoping of the hosting resource belongs with the tenant-isolation work (T2 / #454).
- Account *creation* on first subscribe (vs only suspend/unsuspend existing) — add when the provisioning flow is specced.