### PR TITLE
feat(hosting): tenant-scope web hosting accounts

### DIFF
--- a/app/Models/WebHostingAccount.php
+++ b/app/Models/WebHostingAccount.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use Filament\Facades\Filament;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +11,30 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class WebHostingAccount extends Model
 {
     use HasFactory;
+
+    protected static function booted(): void
+    {
+        // Defense-in-depth: while a Filament tenant is active, scope every query
+        // to it and stamp new records with it. No tenant (console/jobs) => no-op.
+        static::addGlobalScope('tenant', function (Builder $query) {
+            if ($tenant = self::currentTenant()) {
+                $query->where($query->getModel()->getTable().'.team_id', $tenant->getKey());
+            }
+        });
+
+        static::creating(function (self $account) {
+            if ($account->team_id === null && $tenant = self::currentTenant()) {
+                $account->team_id = $tenant->getKey();
+            }
+        });
+    }
+
+    private static function currentTenant(): ?Team
+    {
+        $tenant = Filament::getCurrentPanel() ? Filament::getTenant() : null;
+
+        return $tenant instanceof Team ? $tenant : null;
+    }
 
     protected $fillable = [
         'team_id',

--- a/tests/Feature/Billing/HostingTenantScopeTest.php
+++ b/tests/Feature/Billing/HostingTenantScopeTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\Billing;
+
+use App\Models\Team;
+use App\Models\User;
+use App\Models\WebHostingAccount;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class HostingTenantScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function team(string $name): Team
+    {
+        $user = User::factory()->create();
+
+        return Team::forceCreate([
+            'user_id' => $user->id,
+            'name' => $name,
+            'personal_team' => true,
+        ]);
+    }
+
+    private function actAsTenant(Team $team): void
+    {
+        $this->actingAs($team->owner);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+    }
+
+    private function account(Team $team, string $domain): WebHostingAccount
+    {
+        return WebHostingAccount::withoutGlobalScopes()->create([
+            'team_id' => $team->id,
+            'domain' => $domain,
+            'username' => $domain,
+            'password' => 'secret',
+            'control_panel' => 'cpanel',
+            'status' => 'active',
+        ]);
+    }
+
+    public function test_queries_are_scoped_to_the_current_filament_tenant(): void
+    {
+        $a = $this->team('A');
+        $b = $this->team('B');
+        $this->account($a, 'a.test');
+        $this->account($b, 'b.test');
+
+        $this->actAsTenant($a);
+
+        $domains = WebHostingAccount::query()->pluck('domain');
+
+        $this->assertSame(['a.test'], $domains->all());
+    }
+
+    public function test_no_scope_without_a_tenant(): void
+    {
+        $a = $this->team('A');
+        $b = $this->team('B');
+        $this->account($a, 'a.test');
+        $this->account($b, 'b.test');
+
+        $this->assertCount(2, WebHostingAccount::all());
+    }
+
+    public function test_team_id_is_set_from_tenant_on_create(): void
+    {
+        $a = $this->team('A');
+
+        $this->actAsTenant($a);
+
+        $account = WebHostingAccount::create([
+            'domain' => 'new.test',
+            'username' => 'new',
+            'password' => 'secret',
+            'control_panel' => 'cpanel',
+            'status' => 'active',
+        ]);
+
+        $this->assertSame($a->id, $account->team_id);
+    }
+}


### PR DESCRIPTION
Closes the residual isolation gap flagged in #472 (`team_id` nullable + unscoped reads).

Filament already scopes the Admin `WebHostingAccountResource` to the current Team, but **raw Eloquent reads** in a panel request were unscoped. Adds defense-in-depth at the model:
- global `tenant` scope — while a Filament tenant is active, every query filters by `team_id`; **no tenant (console/jobs) = no-op**
- `creating` hook stamps `team_id` from the current tenant when unset

## Tests (TDD)
`HostingTenantScopeTest` (3): scoped read, no-scope-without-tenant, `team_id` auto-set. Full suite **40 green**.

Prereq for the provision-on-subscribe PR (new accounts must carry a team).