### PR TITLE
feat(billing): provision pending hosting account on first subscribe

### DIFF
--- a/app/Billing/HostingSubscriptionSync.php
+++ b/app/Billing/HostingSubscriptionSync.php
@@ -33,7 +33,20 @@ class HostingSubscriptionSync
             return;
         }
 
-        $this->manager($account->control_panel)->unsuspendAccount($account->username);
+        $manager = $this->manager($account->control_panel);
+
+        // First-time provisioning vs re-enabling a previously suspended account.
+        if ($account->status === 'pending') {
+            $manager->createAccount([
+                'domain' => $account->domain,
+                'username' => $account->username,
+                'password' => $account->password,
+                'control_panel' => $account->control_panel,
+            ]);
+        } else {
+            $manager->unsuspendAccount($account->username);
+        }
+
         $account->update(['status' => 'active']);
     }
 

--- a/tests/Feature/Billing/ProvisionOnSubscribeTest.php
+++ b/tests/Feature/Billing/ProvisionOnSubscribeTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Tests\Feature\Billing;
+
+use App\Billing\HostingSubscriptionSync;
+use App\Models\Team;
+use App\Models\User;
+use App\Models\WebHostingAccount;
+use App\Services\WebHostingControlPanelManager;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Tests\TestCase;
+
+class ProvisionOnSubscribeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function pendingAccount(): array
+    {
+        $user = User::factory()->create();
+        $team = Team::forceCreate([
+            'user_id' => $user->id,
+            'name' => 'Acme',
+            'personal_team' => true,
+        ]);
+        $account = WebHostingAccount::create([
+            'team_id' => $team->id,
+            'domain' => 'acme.test',
+            'username' => 'acme',
+            'password' => 'secret',
+            'control_panel' => 'cpanel',
+            'status' => 'pending',
+        ]);
+
+        return [$team, $account];
+    }
+
+    public function test_active_subscription_provisions_pending_account(): void
+    {
+        [$team, $account] = $this->pendingAccount();
+
+        $manager = Mockery::mock(WebHostingControlPanelManager::class);
+        $manager->shouldReceive('createAccount')->once()
+            ->with(Mockery::on(fn ($data) => $data['domain'] === 'acme.test' && $data['username'] === 'acme'))
+            ->andReturnTrue();
+        $manager->shouldNotReceive('unsuspendAccount');
+        $this->app->bind(WebHostingControlPanelManager::class, fn () => $manager);
+
+        app(HostingSubscriptionSync::class)->apply($team, 'active');
+
+        $this->assertSame('active', $account->fresh()->status);
+    }
+
+    public function test_pending_account_is_not_provisioned_while_unpaid(): void
+    {
+        [$team, $account] = $this->pendingAccount();
+
+        $manager = Mockery::mock(WebHostingControlPanelManager::class);
+        $manager->shouldNotReceive('createAccount');
+        $manager->shouldReceive('suspendAccount')->andReturnTrue();
+        $this->app->bind(WebHostingControlPanelManager::class, fn () => $manager);
+
+        app(HostingSubscriptionSync::class)->apply($team, 'past_due');
+
+        $this->assertSame('suspended', $account->fresh()->status);
+    }
+}


### PR DESCRIPTION
Wires the previously-unused `WebHostingControlPanelManager::createAccount` into the subscription lifecycle (T7 only suspended/unsuspended existing accounts).

`HostingSubscriptionSync::activate`:
- `pending` → `createAccount(...)` — first-time provisioning
- `suspended` → `unsuspendAccount` — re-enable
- `active` → no-op

Flow: create an account in `pending` state → it provisions for real when the Team's subscription goes active, and never while `past_due`/`canceled`.

## Tests (TDD)
`ProvisionOnSubscribeTest` (2): active provisions pending; unpaid does not (suspends). Full suite **39 green**.

Independent of #476 (uses explicit `team_id`); both merge cleanly to main.