### PR TITLE
feat(billing): Stripe billing portal + invoice history

### DIFF
--- a/app/Filament/App/Pages/Billing.php
+++ b/app/Filament/App/Pages/Billing.php
@@ -6,7 +6,9 @@ use App\Billing\Plan;
 use App\Models\Team;
 use Filament\Facades\Filament;
 use Filament\Pages\Page;
+use Illuminate\Http\RedirectResponse;
 use Laravel\Cashier\Checkout;
+use Laravel\Cashier\Invoice;
 
 class Billing extends Page
 {
@@ -47,5 +49,34 @@ class Billing extends Page
                 'success_url' => static::getUrl().'?checkout=success',
                 'cancel_url' => static::getUrl().'?checkout=cancelled',
             ]);
+    }
+
+    public function hasActiveSubscription(): bool
+    {
+        return $this->currentTeam()->subscribed('default');
+    }
+
+    /**
+     * Past invoices for the current Team. Empty until it has a Stripe customer.
+     *
+     * @return array<int, Invoice>
+     */
+    public function invoices(): array
+    {
+        $team = $this->currentTeam();
+
+        return $team->hasStripeId() ? $team->invoices()->all() : [];
+    }
+
+    /**
+     * Redirect to the Stripe-hosted billing portal (manage card, cancel, invoices).
+     */
+    public function manageBilling(): RedirectResponse
+    {
+        $team = $this->currentTeam();
+
+        abort_unless($team->hasStripeId(), 404);
+
+        return $team->redirectToBillingPortal(static::getUrl());
     }
 }

--- a/resources/views/filament/app/pages/billing.blade.php
+++ b/resources/views/filament/app/pages/billing.blade.php
@@ -1,14 +1,27 @@
 <x-filament-panels::page>
-    @php($subscribed = $this->currentTeam()->subscribed('default'))
-
-    @if ($subscribed)
+    @if ($this->hasActiveSubscription())
         <x-filament::section>
             <x-slot name="heading">Current subscription</x-slot>
             <p>Your team has an active subscription.</p>
-            <x-filament::button tag="a" :href="route('cashier.billing-portal') ?? '#'" color="gray">
+            <x-filament::button wire:click="manageBilling" color="gray">
                 Manage billing
             </x-filament::button>
         </x-filament::section>
+
+        @php($invoices = $this->invoices())
+        @if (count($invoices))
+            <x-filament::section>
+                <x-slot name="heading">Invoices</x-slot>
+                <ul class="divide-y">
+                    @foreach ($invoices as $invoice)
+                        <li class="flex items-center justify-between py-2">
+                            <span>{{ $invoice->date()->toFormattedDateString() }} — {{ $invoice->total() }}</span>
+                            <x-filament::link :href="$invoice->hostedInvoiceUrl()" target="_blank">View</x-filament::link>
+                        </li>
+                    @endforeach
+                </ul>
+            </x-filament::section>
+        @endif
     @endif
 
     <div class="grid gap-6 md:grid-cols-2">

--- a/tests/Feature/Billing/BillingPortalTest.php
+++ b/tests/Feature/Billing/BillingPortalTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Tests\Feature\Billing;
+
+use App\Filament\App\Pages\Billing;
+use App\Models\Team;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Tests\TestCase;
+
+class BillingPortalTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function actAsTeam(?string $stripeId = null): Team
+    {
+        $user = User::factory()->create();
+        $team = Team::forceCreate([
+            'user_id' => $user->id,
+            'name' => 'Acme',
+            'personal_team' => true,
+            'stripe_id' => $stripeId,
+        ]);
+
+        $this->actingAs($team->owner);
+        Filament::setCurrentPanel(Filament::getPanel('app'));
+        Filament::setTenant($team);
+
+        return $team;
+    }
+
+    public function test_no_invoices_when_team_has_no_stripe_customer(): void
+    {
+        $this->actAsTeam(stripeId: null);
+
+        $this->assertSame([], (new Billing)->invoices());
+    }
+
+    public function test_has_active_subscription_false_without_subscription(): void
+    {
+        $this->actAsTeam(stripeId: 'cus_x');
+
+        $this->assertFalse((new Billing)->hasActiveSubscription());
+    }
+
+    public function test_manage_billing_aborts_without_stripe_customer(): void
+    {
+        $this->actAsTeam(stripeId: null);
+
+        $this->expectException(NotFoundHttpException::class);
+
+        (new Billing)->manageBilling();
+    }
+}


### PR DESCRIPTION
Extends the App-panel `Billing` page (T5) with self-serve billing management.

- `hasActiveSubscription()` — local check, no API
- `invoices()` — Team's Cashier invoices; **empty until it has a Stripe customer** (no needless API call, no pre-subscribe crash)
- `manageBilling()` — redirect to Stripe-hosted billing portal (manage card, cancel, download invoices); **aborts 404** without a customer
- blade: Manage-billing button + invoice list (date / total / hosted URL)

## Tests (TDD)
`BillingPortalTest` (3): no invoices without customer, no active sub, `manageBilling` aborts without customer — all assert the guards **before** any Stripe call. Full suite **40 green**.

Live portal redirect + invoice fetch verified manually with test keys (needs Stripe creds; not unit-tested).

Independent of #476/#477 — all three merge cleanly to main.