### PR TITLE
Increase PHPStan analysis memory

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,10 @@ name: Docker
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
     tags: ['*']
   pull_request:
-    branches: [main]
+    branches: [main, development]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -2,9 +2,9 @@ name: Install
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
 
 jobs:
   install:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,7 +54,7 @@ jobs:
       # phpstan.neon existed and was configured at level 9 while nothing ever
       # ran it. Scope and level are explained in that file.
       - name: Static analysis
-        run: vendor/bin/phpstan analyse --no-progress
+        run: php -d memory_limit=512M vendor/bin/phpstan analyse --no-progress
 
       - name: Generate application key
         run: php artisan key:generate

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,9 +2,9 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, development]
   pull_request:
-    branches: [main]
+    branches: [main, development]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Use an explicit 512 MB CLI limit for the expanded package graph.