### PR TITLE
Cover absolute profile photo URLs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,9 @@ COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 
 # Copy composer files
 COPY composer.json composer.lock ./
+# The application owns the first-party path repositories declared in composer.json.
+# They must be present before Composer resolves the lock file in the build stage.
+COPY modules ./modules
 
 # Install composer dependencies (no autoloader yet, will optimize in final stage)
 RUN composer install \
@@ -168,4 +171,3 @@ EXPOSE 8080
 ENTRYPOINT ["start-container"]
 
 HEALTHCHECK --start-period=5s --interval=2s --timeout=5s --retries=8 CMD php artisan octane:status || exit 1
-

--- a/tests/Unit/UserContractsTest.php
+++ b/tests/Unit/UserContractsTest.php
@@ -18,3 +18,11 @@ it('implements the Filament tenancy contracts', function () {
         ->toContain(HasTenants::class)
         ->toContain(HasDefaultTenant::class);
 });
+
+it('uses an absolute profile photo URL without rewriting it', function () {
+    $user = User::factory()->make([
+        'profile_photo_path' => 'https://cdn.example.test/avatar.png',
+    ]);
+
+    expect($user->profile_photo_url)->toBe('https://cdn.example.test/avatar.png');
+});


### PR DESCRIPTION
Cover the final uncovered application statement and preserve the 100% release-scope coverage gate.