### PR TITLE
Derive Automation package versions from tags

### DIFF
--- a/modules/module-automation-ai-gateway-api/composer.json
+++ b/modules/module-automation-ai-gateway-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-ai-gateway-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-ai-gateway-filament/composer.json
+++ b/modules/module-automation-ai-gateway-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-ai-gateway-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-ai-gateway-livewire/composer.json
+++ b/modules/module-automation-ai-gateway-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-ai-gateway-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-ai-gateway/composer.json
+++ b/modules/module-automation-ai-gateway/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-ai-gateway"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-approvals-api/composer.json
+++ b/modules/module-automation-approvals-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-approvals-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-approvals-filament/composer.json
+++ b/modules/module-automation-approvals-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-approvals-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-approvals-livewire/composer.json
+++ b/modules/module-automation-approvals-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-approvals-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-approvals/composer.json
+++ b/modules/module-automation-approvals/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-approvals"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-automation-core-api/composer.json
+++ b/modules/module-automation-automation-core-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-automation-core-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-automation-core-filament/composer.json
+++ b/modules/module-automation-automation-core-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-automation-core-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-automation-core-livewire/composer.json
+++ b/modules/module-automation-automation-core-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-automation-core-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-automation-core/composer.json
+++ b/modules/module-automation-automation-core/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-automation-core"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-connectors-api/composer.json
+++ b/modules/module-automation-connectors-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-connectors-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-connectors-filament/composer.json
+++ b/modules/module-automation-connectors-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-connectors-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-connectors-livewire/composer.json
+++ b/modules/module-automation-connectors-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-connectors-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-connectors/composer.json
+++ b/modules/module-automation-connectors/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-connectors"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-data-processing-api/composer.json
+++ b/modules/module-automation-data-processing-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-data-processing-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-data-processing-filament/composer.json
+++ b/modules/module-automation-data-processing-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-data-processing-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-data-processing-livewire/composer.json
+++ b/modules/module-automation-data-processing-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-data-processing-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-data-processing/composer.json
+++ b/modules/module-automation-data-processing/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-data-processing"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-evaluation-api/composer.json
+++ b/modules/module-automation-evaluation-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-evaluation-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-evaluation-filament/composer.json
+++ b/modules/module-automation-evaluation-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-evaluation-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-evaluation-livewire/composer.json
+++ b/modules/module-automation-evaluation-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-evaluation-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-evaluation/composer.json
+++ b/modules/module-automation-evaluation/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-evaluation"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-image-api/composer.json
+++ b/modules/module-automation-image-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-image-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-image-filament/composer.json
+++ b/modules/module-automation-image-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-image-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-image-livewire/composer.json
+++ b/modules/module-automation-image-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-image-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-image/composer.json
+++ b/modules/module-automation-image/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-image"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-prompt-registry-api/composer.json
+++ b/modules/module-automation-prompt-registry-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-prompt-registry-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-prompt-registry-filament/composer.json
+++ b/modules/module-automation-prompt-registry-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-prompt-registry-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-prompt-registry-livewire/composer.json
+++ b/modules/module-automation-prompt-registry-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-prompt-registry-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-prompt-registry/composer.json
+++ b/modules/module-automation-prompt-registry/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-prompt-registry"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-rules-api/composer.json
+++ b/modules/module-automation-rules-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-rules-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-rules-filament/composer.json
+++ b/modules/module-automation-rules-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-rules-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-rules-livewire/composer.json
+++ b/modules/module-automation-rules-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-rules-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-rules/composer.json
+++ b/modules/module-automation-rules/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-rules"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-video-api/composer.json
+++ b/modules/module-automation-video-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-video-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-video-filament/composer.json
+++ b/modules/module-automation-video-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-video-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-video-livewire/composer.json
+++ b/modules/module-automation-video-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-video-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-video/composer.json
+++ b/modules/module-automation-video/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-video"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-voice-api/composer.json
+++ b/modules/module-automation-voice-api/composer.json
@@ -19,7 +19,6 @@
       "name": "module-automation-voice-api"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-voice-filament/composer.json
+++ b/modules/module-automation-voice-filament/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-voice-filament"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-voice-livewire/composer.json
+++ b/modules/module-automation-voice-livewire/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-voice-livewire"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },

--- a/modules/module-automation-voice/composer.json
+++ b/modules/module-automation-voice/composer.json
@@ -18,7 +18,6 @@
       "name": "module-automation-voice"
     }
   },
-  "version": "1.0.0",
   "require-dev": {
     "pestphp/pest": "^5.0"
   },


### PR DESCRIPTION
Remove hard-coded package versions so Packagist can publish the v1.0.3 Git tags for the module-prefixed GitHub repositories and unprefixed Composer names.