### PR TITLE
Make release workflow idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,9 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ github.ref_name }}
-        run: gh release create "$TAG" --generate-notes --verify-tag
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; leaving the published release unchanged."
+          else
+            gh release create "$TAG" --generate-notes --verify-tag
+          fi


### PR DESCRIPTION
The v2.0.0 release was already published before the tag workflow ran, causing the release job to fail on duplicate creation.

This makes release publication idempotent. Development CI passed Tests, Install, and Docker for commit 7660c69f.