### PR TITLE
Fix Kubernetes overlay validation

### DIFF
--- a/k8s/overlays/development/kustomization.yaml
+++ b/k8s/overlays/development/kustomization.yaml
@@ -14,14 +14,19 @@ patches:
   target:
     kind: Deployment
     name: automation-laravel
-
-configMapGenerator:
-- name: automation-config
-  behavior: merge
-  literals:
-  - APP_ENV=development
-  - APP_DEBUG=true
-  - LOG_LEVEL=debug
+- patch: |-
+    - op: replace
+      path: /data/APP_ENV
+      value: development
+    - op: replace
+      path: /data/APP_DEBUG
+      value: "true"
+    - op: replace
+      path: /data/LOG_LEVEL
+      value: debug
+  target:
+    kind: ConfigMap
+    name: automation-config
 
 images:
 - name: ghcr.io/liberusoftware/automation-laravel

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -15,14 +15,19 @@ patches:
   target:
     kind: Deployment
     name: automation-laravel
-
-configMapGenerator:
-- name: automation-config
-  behavior: merge
-  literals:
-  - APP_ENV=production
-  - APP_DEBUG=false
-  - LOG_LEVEL=warning
+- patch: |-
+    - op: replace
+      path: /data/APP_ENV
+      value: production
+    - op: replace
+      path: /data/APP_DEBUG
+      value: "false"
+    - op: replace
+      path: /data/LOG_LEVEL
+      value: warning
+  target:
+    kind: ConfigMap
+    name: automation-config
 
 images:
 - name: ghcr.io/liberusoftware/automation-laravel

--- a/k8s/validate.sh
+++ b/k8s/validate.sh
@@ -34,6 +34,20 @@ check_prerequisites() {
 
 validate_yaml_syntax() {
     log_info "Validating YAML syntax..."
+    # `kubectl apply --dry-run=client` still performs API discovery for some
+    # resource kinds. In a CI runner without a cluster, Kustomize provides the
+    # equivalent parse/render validation and the live-cluster check below is
+    # intentionally handled separately.
+    if ! kubectl cluster-info &> /dev/null; then
+        if kubectl kustomize "$K8S_DIR/base" > /dev/null 2>&1; then
+            log_success "Base resources parse and render successfully (no cluster available)"
+            return 0
+        fi
+
+        log_error "Base Kustomize resources failed to parse"
+        return 1
+    fi
+
     local errors=0
     for file in "$K8S_DIR"/base/*.yaml; do
         if [ -f "$file" ]; then


### PR DESCRIPTION
Fixes the invalid ConfigMap overlay merge strategy and makes the validator work without a live cluster. Both development and production Kustomize overlays now render successfully with client-side validation.