### PR TITLE
Add documentation validation gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Run release verification
         run: scripts/verify-automation-release
 
+      - name: Validate documentation
+        run: php scripts/validate-documentation.php
+
       - name: Publish release
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Validate Automation OpenAPI contracts
         run: php scripts/validate-automation-openapi.php
 
+      - name: Validate documentation
+        run: php scripts/validate-documentation.php
+
       - name: Test Automation packages
         run: scripts/test-automation-packages
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -19,6 +19,7 @@ genre, repository, component paths, prefixes, and additional Composer packages.
 - `measure-phpstan` finds the highest PHPStan level each package's `src/` passes, by bisection over a standalone resolution, writing `storage/app/phpstan.tsv`. Levels are monotone, so four runs settle it instead of eleven.
 - `set-phpstan-levels` writes each measured level into that package's `tests.yml` as the reusable workflow's `phpstan-level` input, ratcheting only upward and preserving the existing `coverage-threshold`.
 - `security-audit` rejects tracked environment files and high-confidence private-key, cloud-key, and access-token patterns; the host Security workflow runs it alongside Composer and npm audits.
+- `validate-documentation.php` checks internal Markdown links and balanced fenced code blocks for the host and tracked package documentation.
 
 All commands are non-interactive and fail on errors. GitHub operations require an
 authenticated `gh` CLI. Packagist operations read `PACKAGIST_USERNAME` and

--- a/scripts/validate-documentation.php
+++ b/scripts/validate-documentation.php
@@ -1,0 +1,66 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+$root = realpath(__DIR__.'/..');
+if ($root === false) {
+    fwrite(STDERR, "Unable to resolve the repository root.\n");
+    exit(1);
+}
+
+$files = [];
+$iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($root));
+foreach ($iterator as $file) {
+    if (! $file->isFile() || $file->getExtension() !== 'md') {
+        continue;
+    }
+
+    $path = $file->getPathname();
+    if (str_contains($path, DIRECTORY_SEPARATOR.'vendor'.DIRECTORY_SEPARATOR)
+        || str_contains($path, DIRECTORY_SEPARATOR.'node_modules'.DIRECTORY_SEPARATOR)) {
+        continue;
+    }
+    $files[] = $path;
+}
+
+$failures = [];
+foreach ($files as $file) {
+    $content = (string) file_get_contents($file);
+    $fenceCount = preg_match_all('/^\s*```/m', $content);
+    if ($fenceCount === false || $fenceCount % 2 !== 0) {
+        $failures[] = relative($root, $file).': unbalanced fenced code block';
+    }
+
+    preg_match_all('/\[[^\]]*\]\(([^)]+)\)/', $content, $matches);
+    foreach ($matches[1] as $target) {
+        $target = trim($target);
+        if ($target === '' || preg_match('/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i', $target)) {
+            continue;
+        }
+
+        $target = trim((string) preg_replace('/\s+.*$/', '', $target));
+        $target = rawurldecode(explode('#', $target, 2)[0]);
+        if ($target === '') {
+            continue;
+        }
+
+        $resolved = realpath(dirname($file).DIRECTORY_SEPARATOR.$target);
+        if ($resolved === false || ! is_file($resolved)) {
+            $failures[] = relative($root, $file).": broken internal link '{$target}'";
+        }
+    }
+}
+
+if ($failures !== []) {
+    fwrite(STDERR, implode("\n", $failures)."\n");
+    fwrite(STDERR, sprintf("Documentation validation failed with %d finding(s).\n", count($failures)));
+    exit(1);
+}
+
+printf("Documentation validation passed for %d Markdown files.\n", count($files));
+
+function relative(string $root, string $path): string
+{
+    return ltrim(str_replace($root, '', $path), DIRECTORY_SEPARATOR);
+}


### PR DESCRIPTION
## Summary
- validate internal Markdown links across host and tracked package documentation
- detect unbalanced fenced code blocks
- run the check in PR tests and tag release verification

## Local verification
- php scripts/validate-documentation.php
- php -l scripts/validate-documentation.php
- scripts/security-audit